### PR TITLE
feat: Store info about date of latest scrapping

### DIFF
--- a/src/main/java/tv/on/Repositories/HistoryRepository.java
+++ b/src/main/java/tv/on/Repositories/HistoryRepository.java
@@ -1,0 +1,14 @@
+package tv.on.Repositories;
+
+import com.neovisionaries.i18n.CountryCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tv.on.models.History;
+
+import java.util.List;
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, Long> {
+
+    List<History> findByCountryCodeOrderByLatestDateWithSchedule(CountryCode countryCode);
+}

--- a/src/main/java/tv/on/Utils.java
+++ b/src/main/java/tv/on/Utils.java
@@ -1,9 +1,12 @@
 package tv.on;
 
 
+import com.neovisionaries.i18n.CountryCode;
+import lombok.SneakyThrows;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 
+import java.lang.reflect.Field;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,5 +18,17 @@ public class Utils {
                 .stream()
                 .filter(clazz -> clazz.getName().endsWith("ScrapperProvider"))
                 .collect(Collectors.toSet());
+    }
+
+    @SneakyThrows
+    public static Integer getIntFieldValueByReflection(Class<?> clazz, String fieldName) {
+        Field field = clazz.getDeclaredField(fieldName);
+        return (Integer) field.get(null);
+    }
+
+    @SneakyThrows
+    public static CountryCode getCountryCodeFieldValueByReflection(Class<?> clazz, String fieldName) {
+        Field field = clazz.getDeclaredField(fieldName);
+        return (CountryCode) field.get(null);
     }
 }

--- a/src/main/java/tv/on/downloaders/ScrapperRunner.java
+++ b/src/main/java/tv/on/downloaders/ScrapperRunner.java
@@ -1,15 +1,22 @@
 package tv.on.downloaders;
 
+import com.neovisionaries.i18n.CountryCode;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import tv.on.Repositories.ChannelRepository;
+import tv.on.Repositories.HistoryRepository;
 import tv.on.Repositories.TVShowRepository;
+import tv.on.Utils;
 import tv.on.models.Channel;
+import tv.on.models.History;
 import tv.on.models.TVShow;
 
 import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,25 +28,43 @@ public class ScrapperRunner {
     ChannelRepository channelRepository;
     @Autowired
     TVShowRepository tvShowRepository;
+	@Autowired
+	HistoryRepository historyRepository;
 
 	@SneakyThrows
     public void startScraping(Class<?> scrapperClass) {
 		Scrapper sc = (Scrapper) scrapperClass.getDeclaredConstructor().newInstance();
-		Field field = scrapperClass.getDeclaredField("NO_DAYS_IN_FUTURE");
-    	Integer noOfDaysInFuture = (Integer) field.get(null);
+    	Integer noOfDaysInFuture = Utils.getIntFieldValueByReflection(scrapperClass,"NO_DAYS_IN_FUTURE");
+		CountryCode countryCode = Utils.getCountryCodeFieldValueByReflection(scrapperClass, "COUNTRY_CODE");
 
 		List<Channel> channels = sc.getAllChannels();
 		channelRepository.saveAll(channels);
 
 		List<TVShow> schedule = new ArrayList<>();
-        for (Channel channel: channels) {
-			LocalDate today = LocalDate.now();
-			for (int i = 1; i <= noOfDaysInFuture; i++) {
-				List<TVShow> tvShowsForDate = sc.getChannelScheduleForDate(today, channel);
+		LocalDateTime startTime = LocalDateTime.now();
+		LocalDate date =  getDateForStartingScrapping(countryCode);
+		LocalDate today = LocalDate.now();
+		int difference = date.getDayOfYear() - today.getDayOfYear();
+		int noOfDaysToRetrieveSchedule = noOfDaysInFuture - difference;
+
+		for (Channel channel: channels) {
+			for (int i = 1; i <= noOfDaysToRetrieveSchedule; i++) {
+				List<TVShow> tvShowsForDate = sc.getChannelScheduleForDate(date, channel);
 				schedule.addAll(tvShowsForDate);
-				today = today.plusDays(1);
+				date = date.plusDays(1);
 			}
 		}
+		LocalDateTime endTime = LocalDateTime.now();
+		historyRepository.save(new History(countryCode, date, startTime, endTime));
 		tvShowRepository.saveAll(schedule);
     }
+
+	private LocalDate getDateForStartingScrapping(CountryCode countryCode) {
+		LocalDate date = LocalDate.now();
+		List<History> historyList = historyRepository.findByCountryCodeOrderByLatestDateWithSchedule(countryCode);
+		if (historyList.isEmpty()) {
+			return date;
+		}
+        return historyList.get(0).getLatestDateWithSchedule();
+	}
 }

--- a/src/main/java/tv/on/downloaders/TelemagazynScrapperProvider.java
+++ b/src/main/java/tv/on/downloaders/TelemagazynScrapperProvider.java
@@ -20,7 +20,7 @@ public class TelemagazynScrapperProvider extends ScrapperBase implements Scrappe
 
     public static final String URL = "https://telemagazyn.pl";
     public static final String CHANNELS_URL = URL + "/stacje";
-    public static final Integer NO_DAYS_IN_FUTURE = 6;
+    public static final Integer c = 6;
     public static final CountryCode COUNTRY_CODE = CountryCode.getByCode("PL");
 
     @Override

--- a/src/main/java/tv/on/models/History.java
+++ b/src/main/java/tv/on/models/History.java
@@ -1,0 +1,36 @@
+package tv.on.models;
+
+import com.neovisionaries.i18n.CountryCode;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
+public class History {
+    @Id
+    @SequenceGenerator(
+            name = "_sequence",
+            sequenceName = "history_sequence",
+            allocationSize = 1
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "history_sequence"
+    )
+    public Long id;
+    @NonNull
+    public CountryCode countryCode;
+    @NonNull
+    public LocalDate latestDateWithSchedule;
+    @NonNull
+    public LocalDateTime latestScrappingStartTime;
+    @NonNull
+    public LocalDateTime latestScrappingEndTime;
+}

--- a/src/main/java/tv/on/scheduler/ScrapperScheduler.java
+++ b/src/main/java/tv/on/scheduler/ScrapperScheduler.java
@@ -7,7 +7,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import tv.on.downloaders.ScrapperRunner;
 
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.Set;
 


### PR DESCRIPTION
Previously scrapper was scrapping on each start
NO_DAYS_IN_FUTURE days. Now it remembers latest
scrapped date and on next run it scrapps only
NO_DAYS_IN_FUTURE - latest scrapp date days.